### PR TITLE
Fix for calling parse() in export_rtd()

### DIFF
--- a/Python/rtmaps.py
+++ b/Python/rtmaps.py
@@ -554,7 +554,7 @@ class RTMapsAbstraction(RTMapsWrapper):
         command = "exportdiagramas <<{}>>".format(file_path)
         if overwrite:
             command += " overwrite"
-        self.parse(command, add_to_command_log=False)
+        self.parse(command)
 
     def check_action_availability(self, component_id, action):
         if self._enable_checks:


### PR DESCRIPTION
This pull request removes a non-existing argument when calling parse() in export_rtd().