### PR TITLE
An extension to the RTMapsAbstraction to inject environ

### DIFF
--- a/Python/rtmaps.py
+++ b/Python/rtmaps.py
@@ -11,10 +11,12 @@ from pathlib import Path
 import re
 import time
 import xml.etree.ElementTree as et
-from ctypes import Structure, POINTER, c_ubyte, c_double, c_int32, c_int64, c_uint32, c_int8, sizeof, c_bool
-from ctypes import byref, create_string_buffer, cdll
-from ctypes import c_void_p, c_char_p
-from ctypes import c_int, c_double
+from ctypes import (
+    Structure, POINTER,
+    sizeof,
+    c_double, c_int64, c_int32, c_uint32, c_int, c_int8, c_ubyte, c_bool, c_void_p, c_char_p,
+    CDLL,
+)
 
 from numpy import int64
 if sys.platform == "win32":
@@ -495,6 +497,15 @@ class RTMapsAbstraction(RTMapsWrapper):
             super(RTMapsAbstraction, self).__init__("--console", x11_option, *args)
         elif sys.platform == "win32":
             super(RTMapsAbstraction, self).__init__("--console", *args)
+        self._inject_environ()
+
+    def _inject_environ(self):
+        c_environ = c_void_p.in_dll(CDLL(None), "environ")
+        try:
+            c_rtmaps_environ = c_void_p.in_dll(self.lib, "environ")
+            c_rtmaps_environ.value = c_environ.value
+        except ValueError:
+            logging.warning("Failed to inject 'environ' into the rtmaps environment!")
 
     def _add_component_internal(self, component_type: str, component_id: str):
         self._components.add(component_id)

--- a/Python/rtmaps.py
+++ b/Python/rtmaps.py
@@ -12,10 +12,10 @@ import re
 import time
 import xml.etree.ElementTree as et
 from ctypes import (
-    Structure, POINTER,
-    sizeof,
+    Structure, CDLL, 
     c_double, c_int64, c_int32, c_uint32, c_int, c_int8, c_ubyte, c_bool, c_void_p, c_char_p,
-    CDLL,
+    POINTER, sizeof, byref, create_string_buffer,
+    cdll, 
 )
 
 from numpy import int64


### PR DESCRIPTION
An extension to the RTMapsAbstraction due to support case #8238 (https://support.intempora.com/hc/requests/8238)

Michael Israel helped to find a solution to Inject environ from Python's environment into the RTMaps library's. As the result, with RTMapsAbstraction, when there is any component in the diagram using POSIX API (posix_spawnp) to spawn subprocess, the required argument environ can be filled with the system environmental variables correctly.